### PR TITLE
Remove ->forwardAgent(), plus other notes

### DIFF
--- a/docs/enable-feature-ssh-forward-agent.md
+++ b/docs/enable-feature-ssh-forward-agent.md
@@ -3,7 +3,9 @@
    Host <your-server-ip>
      ForwardAgent yes
    ```
-
+    Note: if on your team, each user connects using their own server account, you should also each specify `User <your-server-user>` here in the config instead of with a deployer `->user('username')` call (which would require a single server account _username_ to be used by the whole team).
+    > it’s better to omit information such as user, port, identityFile, forwardAgent and use it from the ~/.ssh/config file instead —[Deployer docs 'Hosts'](https://deployer.org/docs/hosts.html)
+    
 2. On your server, uncomment line `#AllowAgentForwarding yes` in file `/etc/ssh/sshd_config` to allow agent forwarding feature.
    ```
    AllowAgentForwarding yes
@@ -15,6 +17,8 @@
    ```shell
    $ sudo service sshd restart
    ```
+
+Note: Some servers enaable AllowAgentForwarding by default, in which case it will be allowed unless there is an entry `AllowAgentForwarding no`, so this step may not be necessary.
 
 3. Test forward agent from your local machine.
    ```ssh
@@ -28,8 +32,7 @@
 
    ```php
    server('your-server', 'xxx.xxx.xxx.xxx', 22)
-       ->user('username')
-       ->forwardAgent()
+       ->user('username')  // Omit if specifying User in ssh config
        ->stage(['dev'])
        ->env('deploy_path', '/var/www/apps/yourappname')
        ->env('branch', 'master')


### PR DESCRIPTION
I found this page very helpful in figuring out agent forwarding with deployer, thanks.

I offer this PR with some suggested edits:
1. Removes `->forwardAgent()`, which is not needed (at least in current versions of deployer, I tested on v4.3) when ssh config has `ForwardAgent yes` — and https://deployer.org/docs/hosts.html specifically recommends _not_ calling `->forwardAgent()` and instead having it in the ssh config
2. Adds notes about also specifying the user in ssh config instead of `->user('username')` (similar recommendation in the docs), in this case just as a note since perhaps some teams use a specific account for deploying and therefore are fine sharing it.